### PR TITLE
Bug Fix - Player guess is always Incorrect

### DIFF
--- a/WheelOfFortune.java
+++ b/WheelOfFortune.java
@@ -127,8 +127,8 @@ public class WheelOfFortune
 			{
 				System.out.print("Please Enter Your Guess: ");
 				keyboard = new Scanner(System.in);
-				String playerGuess = keyboard.next().trim();
-				
+				String playerGuess = keyboard.nextLine().trim();
+
 				if (!playerGuess.equalsIgnoreCase(fortuneBoard.getPuzzle())) 
 				{
 					System.out.println("\nIncorrect!\n");


### PR DESCRIPTION
When a player guesses the puzzle by entering the movie name, always shows Incorrect.
This is because, `keyboard.next()` -> takes in only the first Word entered before giving a space

**Example:
Input: The Secret Life of Bees
Output: The**

Here is the code:

> System.out.print("Please Enter Your Guess: ");
> keyboard = new Scanner(System.in);
> String playerGuess = keyboard.next().trim();

Change that needs to be done:

> keyboard.nextLine().trim()